### PR TITLE
response is returned as json; expires is renamed to expires_in

### DIFF
--- a/FacebookStrategy.php
+++ b/FacebookStrategy.php
@@ -61,7 +61,7 @@ class FacebookStrategy extends OpauthStrategy
 			);
 			$response = $this->serverGet($url, $params, null, $headers);
 
-			parse_str($response, $results);
+			$results = json_decode($response, true);
 
 			if (!empty($results) && !empty($results['access_token'])){
 				$me = $this->me($results['access_token']);
@@ -75,7 +75,7 @@ class FacebookStrategy extends OpauthStrategy
 					),
 					'credentials' => array(
 						'token' => $results['access_token'],
-						'expires' => date('c', time() + $results['expires'])
+						'expires' => date('c', time() + $results['expires_in'])
 					),
 					'raw' => $me
 				);


### PR DESCRIPTION
json_decode $response and populate the $results;
using 'expires_in' key from response vs 'expires'